### PR TITLE
Update to present tense

### DIFF
--- a/cmd/consumer/responses.go
+++ b/cmd/consumer/responses.go
@@ -205,7 +205,7 @@ func injectMessageResponses(ma *handler.MessageActions) {
 	)
 
 	ma.HandleStatic("source code", "where does this bot's source live?", []string{"source"},
-		`You can find my source code, included all of my configured responses, here:`,
+		`You can find my source code, including all of my configured responses, here:`,
 		`- <https://github.com/gobridge/gopherbot>`,
 	)
 


### PR DESCRIPTION
The sentence for the `source code` response was refactored with the tense
changed. This updates one word to match the present tense.