### PR TITLE
Initial commit of built-in glossary of terms, using define command

### DIFF
--- a/glossary/glossary.go
+++ b/glossary/glossary.go
@@ -1,0 +1,74 @@
+// Package glossary provides some common terms that might be handy for a Gopher
+// to know.
+package glossary
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gobridge/gopherbot/handler"
+	"github.com/gobridge/gopherbot/workqueue"
+)
+
+// Prefix is the prefix that's intended to be used by the handler.
+const Prefix = "define "
+
+// Terms represents the glossary.
+type Terms struct {
+	entries map[string][]string
+	aliases map[string]string
+	prefix  string
+}
+
+// New generates a new set of glossary terms, from those it returns Terms.
+func New(prefix string) Terms {
+	t := &Terms{
+		entries: make(map[string][]string),
+		aliases: make(map[string]string),
+		prefix:  prefix,
+	}
+
+	for _, tfn := range terms {
+		tfn(t)
+	}
+
+	return *t
+}
+
+// DefineHandler satisfiees handler.MessageActionFn. It handles finding definitions for specific terms.
+func (t Terms) DefineHandler(ctx workqueue.Context, m handler.Messenger, r handler.Responder) error {
+	if !m.BotMentioned() {
+		return nil
+	}
+
+	term := m.Text()[len(t.prefix):]
+
+	// this probably isn't possible with how Slack sends messages
+	// but let's have it just in case...
+	if len(term) == 0 {
+		return r.RespondTo(ctx, "You need to specify a term to define")
+	}
+
+	lterm := strings.ToLower(term)
+	lt := lterm
+
+	if v, ok := t.aliases[lterm]; ok {
+		lt = v
+	}
+
+	d, ok := t.entries[lt]
+	if !ok {
+		return r.RespondTo(ctx, "I'm sorry, I don't have a definition for that.")
+	}
+
+	ds := strings.Join(d, "\n")
+
+	var msg string
+	if lt != lterm { // alias was used
+		msg = fmt.Sprintf("`%s`, or `%s`, is %s", lt, lterm, ds)
+	} else {
+		msg = fmt.Sprintf("`%s` is %s", lt, ds)
+	}
+
+	return r.RespondMentions(ctx, msg)
+}

--- a/glossary/terms.go
+++ b/glossary/terms.go
@@ -1,0 +1,35 @@
+package glossary
+
+import "fmt"
+
+var terms = []gOption{
+	// terms represents all the terms known by the glossary
+	//
+	// when adding items, please order alphabetically by the term
+
+	define("dependency injection", []string{"di"},
+		`a technique in which a type or function receives other things that it depends on, such as a database handler or logger`,
+		``,
+		"Note: my `dependency injection` command provides more details on how to use dependency injection in Go.",
+	),
+}
+
+type gOption func(t *Terms)
+
+func define(term string, aliases []string, content ...string) gOption {
+	return func(t *Terms) {
+		if _, ok := t.entries[term]; ok {
+			panic(fmt.Sprintf("term %s already defined", term))
+		}
+
+		for _, a := range aliases {
+			if v, ok := t.aliases[a]; ok {
+				panic(fmt.Sprintf("alias %s already exists to %s", a, v))
+			}
+
+			t.aliases[a] = term
+		}
+
+		t.entries[term] = content
+	}
+}

--- a/handler/message_actions.go
+++ b/handler/message_actions.go
@@ -222,7 +222,7 @@ func isDM(c ChannelType) bool {
 // handlers are only invoked if the bot was mentioned.
 func (m *MessageActions) Match(message Message) []MessageAction {
 	message.text, message.allMentions = mparser.ParseAndSplice(message.rawText, message.channelID)
-	message.text = strings.TrimSpace(message.text)
+	message.text = strings.TrimSpace(message.text) // Slack already trims the space off the end
 
 	message.userMentions, message.botMentioned = onlyOtherUserMMentions(m.selfID, message.allMentions)
 
@@ -239,7 +239,7 @@ func (m *MessageActions) Match(message Message) []MessageAction {
 
 	dm := isDM(message.channelType)
 
-	if dm || !m.shadowMode {
+	if dm || message.botMentioned || !m.shadowMode {
 		for k, v := range m.reactions {
 			if strings.Contains(lt, k) && (!v.onlyWhenMentioned || message.botMentioned) {
 				a := MessageAction{


### PR DESCRIPTION
Well, singular. Starting out with one term for the initial pass, and will
crowd-source more of them.

This also adds another method to the Responder, `RespondTo`, for mentioning the
user who triggered the command in the response.

Updates #6