### PR TITLE
Add support for replying to shared threaded messages

### DIFF
--- a/handler/channel_join.go
+++ b/handler/channel_join.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/rs/zerolog"
-	"github.com/slack-go/slack/slackevents"
 	"github.com/gobridge/gopherbot/mparser"
 	"github.com/gobridge/gopherbot/workqueue"
+	"github.com/rs/zerolog"
+	"github.com/slack-go/slack/slackevents"
 )
 
 // ChannelJoiner is the interface to represent an incoming team join event.
@@ -62,7 +62,7 @@ func (c *ChannelJoinActions) Handler(ctx workqueue.Context, cj *slackevents.Memb
 		Type: mparser.TypeUser,
 		ID:   j.userID,
 	}
-	msg := NewMessage(j.channelID, cj.ChannelType, j.userID, "", "", "", nil)
+	msg := NewMessage(j.channelID, cj.ChannelType, j.userID, "", "", "", "", nil)
 	msg.allMentions = []mparser.Mention{mention}
 	msg.userMentions = []mparser.Mention{mention}
 

--- a/handler/message_actions.go
+++ b/handler/message_actions.go
@@ -122,8 +122,8 @@ func (m *MessageActions) Registered() []RegisteredMessageHandler {
 }
 
 func shouldDiscard(m *slackevents.MessageEvent) (string, bool) {
-	if len(m.SubType) > 0 {
-		return "message has subtype", true
+	if len(m.SubType) > 0 && m.SubType != "thread_broadcast" {
+		return fmt.Sprintf("message has subtype %s", m.SubType), true
 	}
 
 	tss := strings.Split(m.TimeStamp, ".")[0]
@@ -156,7 +156,7 @@ func (m *MessageActions) Handler(ctx workqueue.Context, me *slackevents.MessageE
 
 	actions := m.Match(
 		NewMessage(
-			me.Channel, me.ChannelType, me.User, me.ThreadTimeStamp, me.TimeStamp, me.Text, me.Files,
+			me.Channel, me.ChannelType, me.User, me.ThreadTimeStamp, me.TimeStamp, me.SubType, me.Text, me.Files,
 		),
 	)
 

--- a/handler/messenger.go
+++ b/handler/messenger.go
@@ -1,8 +1,8 @@
 package handler
 
 import (
-	"github.com/slack-go/slack/slackevents"
 	"github.com/gobridge/gopherbot/mparser"
+	"github.com/slack-go/slack/slackevents"
 )
 
 // ChannelType represents where a message was sent.
@@ -109,6 +109,7 @@ type Message struct {
 	userID       string
 	threadTS     string
 	messageTS    string
+	subType      string
 	allMentions  []mparser.Mention
 	userMentions []mparser.Mention
 	text         string
@@ -120,13 +121,14 @@ type Message struct {
 var _ Messenger = Message{}
 
 // NewMessage generates a new message from the various inputs.
-func NewMessage(channelID, channelType, userID, threadTS, messageTS, text string, files []slackevents.File) Message {
+func NewMessage(channelID, channelType, userID, threadTS, messageTS, subType, text string, files []slackevents.File) Message {
 	return Message{
 		channelID:   channelID,
 		channelType: strToChan(channelType),
 		userID:      userID,
 		threadTS:    threadTS,
 		messageTS:   messageTS,
+		subType:     subType,
 		rawText:     text,
 		files:       files,
 	}
@@ -146,6 +148,9 @@ func (m Message) ThreadTS() string { return m.threadTS }
 
 // MessageTS satisfies the Messenger interface.
 func (m Message) MessageTS() string { return m.messageTS }
+
+// SubType satisfies the Messenger interface.
+func (m Message) SubType() string { return m.subType }
 
 // AllMentions satisfies the Messenger interface.
 func (m Message) AllMentions() []mparser.Mention { return m.allMentions }

--- a/handler/team_join.go
+++ b/handler/team_join.go
@@ -3,10 +3,10 @@ package handler
 import (
 	"fmt"
 
-	"github.com/rs/zerolog"
-	"github.com/slack-go/slack"
 	"github.com/gobridge/gopherbot/mparser"
 	"github.com/gobridge/gopherbot/workqueue"
+	"github.com/rs/zerolog"
+	"github.com/slack-go/slack"
 )
 
 // TeamJoiner is the interface to represent an incoming team join event.
@@ -47,7 +47,7 @@ func (t *TeamJoinActions) Handler(ctx workqueue.Context, tj *slack.TeamJoinEvent
 		Type: mparser.TypeUser,
 		ID:   j.ID,
 	}
-	msg := NewMessage(j.ID, "im", j.ID, "", "", "", nil)
+	msg := NewMessage(j.ID, "im", j.ID, "", "", "", "", nil)
 	msg.allMentions = []mparser.Mention{mention}
 	msg.userMentions = []mparser.Mention{mention}
 


### PR DESCRIPTION
When messages are shared from a thread the include a SubType, which so far has
been our indicator to drop the message. This updates the code to no longer drop
those messages, and to also share our reply with the channel.

Fixes #13