### PR TITLE
Use messageToPlayground for better playground code

### DIFF
--- a/cmd/consumer/playground/playground.go
+++ b/cmd/consumer/playground/playground.go
@@ -197,7 +197,7 @@ func (c *Client) MessageMatchFn(shadowMode bool, m handler.Messenger) bool {
 	return true
 }
 
-// postToPlayground converts the text of a post into code for the playground. It is not perfect but works most of the time.
+// messageToPlayground converts the text of a post into code for the playground. It is not perfect but works most of the time.
 // Text outside of ``` quotes is converted into a comment and included in the code, everything inside of those quotes is
 // considered code and pasted as-is.
 func messageToPlayground(text string) *bytes.Buffer {


### PR DESCRIPTION
This PR adds a function to convert a message text to proper playground code.
Code blocks are pasted as is, text is added as a comment.

As mentioned in #12 this is a resubmission of https://github.com/gobridge/gopher/pull/39