### PR TITLE
Unlearn replying to thread_broadcast messages with its own broadcast

### DIFF
--- a/handler/message_actions.go
+++ b/handler/message_actions.go
@@ -126,6 +126,17 @@ func shouldDiscard(m *slackevents.MessageEvent) (string, bool) {
 		return fmt.Sprintf("message has subtype %s", m.SubType), true
 	}
 
+	// TODO(theckman): as of now the bot is unable to recognize whether a
+	// thread_broadcast message was from itself or not. We need to add support
+	// for parsing the root subkey of the thread_broadcast message event:
+	// https://api.slack.com/events/message/thread_broadcast, because that's the
+	// user we care about.
+	//
+	// Once that's added we should discard thread_broadcast messages from
+	// ourselves.
+	//
+	// Also, see related TODO in responder.go.
+
 	tss := strings.Split(m.TimeStamp, ".")[0]
 
 	// we assume this is a well-formed message

--- a/handler/responder.go
+++ b/handler/responder.go
@@ -152,9 +152,14 @@ func (r response) respond(ctx context.Context, mentionUser, useMentions, ephemer
 
 	// if it's a command that was triggered in a shared thread reply
 	// we should share our reply with the channel too
-	if len(subType) > 0 && subType == "thread_broadcast" {
-		opts = append(opts, slack.MsgOptionBroadcast())
-	}
+	//
+	// TODO(theckman): re-enable this functionality once gopher is able to
+	// recognize thread_broadcast messages from itself. See TODO in
+	// message_actions.go for more context.
+	//
+	// if len(subType) > 0 && subType == "thread_broadcast" {
+	// 	opts = append(opts, slack.MsgOptionBroadcast())
+	// }
 
 	if len(attachments) > 0 {
 		opts = append(opts, slack.MsgOptionAttachments(attachments...))


### PR DESCRIPTION
The Go Slack client is missing the field on the MessageEvent that would allow us
to identify who the sender of the message was. Specifically, the `root` key as
shown here: https://api.slack.com/events/message/thread_broadcast

Until that can be done, this disables the bot's ability to reply to broadcasted
messages with a broadcast.