### PR TITLE
Unescape code before sending it to playground

### DIFF
--- a/cmd/consumer/playground/playground.go
+++ b/cmd/consumer/playground/playground.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"html"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -202,6 +203,9 @@ func (c *Client) MessageMatchFn(shadowMode bool, m handler.Messenger) bool {
 // considered code and pasted as-is.
 func messageToPlayground(text string) *bytes.Buffer {
 	var buf bytes.Buffer
+
+	// unescape the post to prevent the insertion of HTML escapes into the playground
+	text = html.UnescapeString(text)
 	parts := strings.Split(text, "```")
 
 	for i, part := range parts {

--- a/cmd/consumer/playground/playground.go
+++ b/cmd/consumer/playground/playground.go
@@ -217,9 +217,9 @@ func messageToPlayground(text string) *bytes.Buffer {
 				continue
 			}
 
-			buf.WriteString("// ")
+			buf.WriteString("\n// ")
 			buf.WriteString(strings.Replace(part, "\n", "\n// ", -1))
-			buf.WriteByte('\n')
+			buf.WriteString("\n\n")
 		} else {
 			// it's code
 			if part == "" {


### PR DESCRIPTION
This PR adds a step to unescape HTML in a post before sending it to the playground. It also adds newlines around the comments to separate them more clearly from the code.

A good example of why this is necessary was posted in # newbies recently: https://play.golang.org/p/m6Z8iNSXnZ9