### PR TITLE
Fix missing twitter handle from recommended twitter feeds

### DIFF
--- a/cmd/consumer/responses.go
+++ b/cmd/consumer/responses.go
@@ -180,7 +180,7 @@ func injectMessageResponses(ma *handler.MessageActions) {
 		`- Dave Cheney <https://twitter.com/davecheney|@davecheney> - <http://dave.cheney.net>`,
 		`- Jaana Burcu Dogan <https://twitter.com/rakyll|@rakyll> - <http://golang.rakyll.org>`,
 		`- Jessie Frazelle <https://twitter.com/jessfraz|@jessfraz> - <https://blog.jessfraz.com>`,
-		`- William "Bill" Kennedy <https://twitter.com|@goinggodotnet> - <https://www.goinggo.net>`,
+		`- William "Bill" Kennedy <https://twitter.com/goinggodotnet|@goinggodotnet> - <https://www.goinggo.net>`,
 		`- Brian Ketelsen <https://twitter.com/bketelsen|@bketelsen> - <https://www.brianketelsen.com/blog>`,
 	)
 


### PR DESCRIPTION
This pr will fix the twitter link for `William "Bill" Kennedy`

![image](https://user-images.githubusercontent.com/22951010/118722175-84c14180-b834-11eb-9efb-234c263c63a8.png)
