### PR TITLE
Go Playground moved from play.golang.org to go.dev/play/

### DIFF
--- a/cmd/consumer/playground/playground.go
+++ b/cmd/consumer/playground/playground.go
@@ -74,7 +74,7 @@ func (c *Client) pgForMessage(ctx workqueue.Context, m handler.Messenger, r hand
 
 	err = r.RespondEphemeral(ctx, `I've noticed you've written a large block of text (more than 9 lines). `+
 		`To faciliate collaboration and make the conversation easier to follow, `+
-		`please consider using <https://play.golang.org> to share code. If you wish to not `+
+		`please consider using <https://go.dev/play/> to share code. If you wish to not `+
 		`link against the playground, please start the message with "nolink". Thank you!`,
 	)
 	if err != nil {
@@ -131,7 +131,7 @@ func (c *Client) pgForFiles(ctx workqueue.Context, m handler.Messenger, r handle
 
 	err := r.RespondEphemeral(ctx, `I've noticed you uploaded a Go file. To facilitate collaboration and make `+
 		`it easier for others to share back the snippet, please consider using: `+
-		`<https://play.golang.org>. If you wish to not link against the playground, please use `+
+		`<https://go.dev/play/>. If you wish to not link against the playground, please use `+
 		`"nolink" in the message. Thank you!`,
 	)
 	if err != nil {
@@ -144,7 +144,7 @@ func (c *Client) pgForFiles(ctx workqueue.Context, m handler.Messenger, r handle
 }
 
 func (c *Client) upload(ctx context.Context, body io.Reader) (link string, err error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://play.golang.org/share", body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://go.dev/_/share", body)
 	if err != nil {
 		return "", err
 	}
@@ -168,7 +168,7 @@ func (c *Client) upload(ctx context.Context, body io.Reader) (link string, err e
 		return "", fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	return "https://play.golang.org/p/" + string(id), nil
+	return "https://go.dev/play/p/" + string(id), nil
 }
 
 // MessageMatchFn satisfies handler.MessageMatchFn

--- a/cmd/consumer/responses.go
+++ b/cmd/consumer/responses.go
@@ -274,7 +274,7 @@ func injectMessageResponses(ma *handler.MessageActions) {
 
 	ma.HandleStatic("playground", "info on sharing Go code via the Go Playground", []string{"go playground", "goplay", "goplay space"},
 		`Please share your code via the Go Playground. The Playground offers a specialized runtime environment, that others can use to read your code, iterate on it, and share it back with you:`,
-		`- <https://play.golang.org/>`,
+		`- <https://go.dev/play/>`,
 		`There is also this stylized alternate front-end: <https://goplay.space/>`,
 	)
 
@@ -286,7 +286,7 @@ func injectMessageResponses(ma *handler.MessageActions) {
 	)
 
 	ma.HandleStatic("screenshots", "why you shouldn't use screenshots", []string{"screenshot"},
-		`Screenshots are neither easy to read nor very accessible for many people. Please consider copying code, errors, or command output into a Slack snippet, the <https://play.golang.org/|Go Playground>, or a <https://gist.github.com/|GitHub Gist>.`,
+		`Screenshots are neither easy to read nor very accessible for many people. Please consider copying code, errors, or command output into a Slack snippet, the <https://go.dev/play/|Go Playground>, or a <https://gist.github.com/|GitHub Gist>.`,
 	)
 
 	ma.HandleStatic("go tour", "link to the Go tour", []string{"tour"},

--- a/cmd/consumer/team_join.go
+++ b/cmd/consumer/team_join.go
@@ -80,7 +80,7 @@ If you'd like to learn more about the functions I offer, please send me the ` + 
 
 There is also a forum <https://forum.golangbridge.org>, which you might want to check it out as well if a Forum is more your style.
 
-<#%s> can sometimes seem busy, but please don't hesitate to ask your Go related questions there. To share code while asking a question, you should use: <https://play.golang.org/> as it makes it easy for others to help you.
+<#%s> can sometimes seem busy, but please don't hesitate to ask your Go related questions there. To share code while asking a question, you should use: <https://go.dev/play/> as it makes it easy for others to help you.
 
 Here's a list of a few other channels you could join:
 %s


### PR DESCRIPTION
The Go Playground has been moved from <https://play.golang.org> to <https://go.dev/play/>

This PR updates the links used by the bot when it mentions the playground 
(as well as the endpoint used when uploading a snippet to the playground)